### PR TITLE
Put more emphasis on catconfig in catalog docs.

### DIFF
--- a/doc/catalogs.md
+++ b/doc/catalogs.md
@@ -137,7 +137,7 @@ e.g.:
 There was an issue recently where `cldfbench` couldn't actually see the config
 file even it was well-formed and clearly visible in the Windows file manager.
 Even more curiously, the file created by `catconfig` was invisible in the
-Windows file manager (but still worked perfectly file).  Maybe it's a weird file
+Windows file manager (but still worked perfectly fine).  Maybe it's a weird file
 permission issue.  Who knows.
 
 Should you encounter this problem, you'll have to use `cldfbench catconfig` to


### PR DESCRIPTION
@MiraAhmedovic and I hit a weird issue on Windows 11 where *cldfcatalog* wouldn't pick up the *catalog.ini* even if it was there and wellformed.

Weirdly enough it would work when the file was created using *cldfbench catconfig*.  Even more weirdly the file doesn't show up in the file manager anymore.  But it still works so maybe it's some file permission nonsense or something idk.

Either way, I reframed the documentation so it recommends *cldfbench catconfig* first and describes the manual set up as an *if you really want to* option (and added a note about our issue today).  I think that would be a better way to get people started anyways.
